### PR TITLE
addPageHandler() added to allow register handlers on page events (hide, show, ...).

### DIFF
--- a/library/src/main/java/com/sksamuel/jqm4gwt/JQMPage.java
+++ b/library/src/main/java/com/sksamuel/jqm4gwt/JQMPage.java
@@ -9,6 +9,7 @@ import com.google.gwt.uibinder.client.UiConstructor;
 import com.google.gwt.user.client.Cookies;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
+import com.sksamuel.jqm4gwt.JQMPageEvent.PageState;
 import com.sksamuel.jqm4gwt.toolbar.JQMFooter;
 import com.sksamuel.jqm4gwt.toolbar.JQMHeader;
 import com.sksamuel.jqm4gwt.toolbar.JQMPanel;
@@ -213,35 +214,35 @@ public class JQMPage extends JQMContainer implements HasFullScreen<JQMPage> {
 
     private native void bindLifecycleEvents(JQMPage p, String id) /*-{
 
-												$wnd.$('div[data-url="' + id + '"]').bind("pageshow",
-												function(event, ui) {
-												p.@com.sksamuel.jqm4gwt.JQMPage::onPageShow()();
-												});
-												
-												$wnd.$('div[data-url="' + id + '"]').bind("pagehide",
-												function(event, ui) {
-												p.@com.sksamuel.jqm4gwt.JQMPage::onPageHide()();
-												});
-												
-												$wnd.$('div[data-url="' + id + '"]').bind("pagebeforehide",
-												function(event, ui) {
-												p.@com.sksamuel.jqm4gwt.JQMPage::onPageBeforeHide()();
-												});
-												
-												$wnd.$('div[data-url="' + id + '"]').bind("pagebeforeshow",
-												function(event, ui) {
-												p.@com.sksamuel.jqm4gwt.JQMPage::onPageBeforeShow()();
-												});
-												
-												}-*/;
+        $wnd.$('div[data-url="' + id + '"]').bind("pageshow",
+            function(event, ui) {
+                p.@com.sksamuel.jqm4gwt.JQMPage::doPageShow()();
+            });
+        
+        $wnd.$('div[data-url="' + id + '"]').bind("pagehide",
+            function(event, ui) {
+                p.@com.sksamuel.jqm4gwt.JQMPage::doPageHide()();
+            });
+        
+        $wnd.$('div[data-url="' + id + '"]').bind("pagebeforehide",
+            function(event, ui) {
+                p.@com.sksamuel.jqm4gwt.JQMPage::doPageBeforeHide()();
+            });
+        
+        $wnd.$('div[data-url="' + id + '"]').bind("pagebeforeshow",
+            function(event, ui) {
+                p.@com.sksamuel.jqm4gwt.JQMPage::doPageBeforeShow()();
+            });
+        
+    }-*/;
 
     private native void unbindLifecycleEvents(String id) /*-{
-												$wnd.$('div[data-url="' + id + '"]').unbind("pageshow");	
-												$wnd.$('div[data-url="' + id + '"]').unbind("pagehide");
-												$wnd.$('div[data-url="' + id + '"]').unbind("pagebeforehide");
-												$wnd.$('div[data-url="' + id + '"]').unbind("pagebeforeshow");
-	
-												}-*/;
+        $wnd.$('div[data-url="' + id + '"]').unbind("pageshow");	
+        $wnd.$('div[data-url="' + id + '"]').unbind("pagehide");
+        $wnd.$('div[data-url="' + id + '"]').unbind("pagebeforehide");
+        $wnd.$('div[data-url="' + id + '"]').unbind("pagebeforeshow");
+
+    }-*/;
 
     protected void onLoad()
     {
@@ -352,25 +353,47 @@ public class JQMPage extends JQMContainer implements HasFullScreen<JQMPage> {
      */
     protected void onPageBeforeHide() {
     }
+    
+    protected void doPageBeforeHide() {
+        onPageBeforeHide();
+        JQMPageEvent.fire(this, PageState.BEFORE_HIDE);
+    }
 
     /**
      * Triggered on the page being shown, before its transition begins.
      */
     protected void onPageBeforeShow() {
     }
+    
+    protected void doPageBeforeShow() {
+        onPageBeforeShow();
+        JQMPageEvent.fire(this, PageState.BEFORE_SHOW);
+    }
 
     /**
      * Triggered on the page being hidden, after its transition completes.
      */
     protected void onPageHide() {
-
+    }
+    
+    protected void doPageHide() {
+        onPageHide();
+        JQMPageEvent.fire(this, PageState.HIDE);
     }
 
     /**
      * Triggered on the page being hidden, after its transition completes.
      */
     protected void onPageShow() {
-
+    }
+    
+    protected void doPageShow() {
+        onPageShow();
+        JQMPageEvent.fire(this, PageState.SHOW);
+    }
+    
+    public HandlerRegistration addPageHandler(JQMPageEvent.Handler handler) {
+        return addHandler(handler, JQMPageEvent.getType());
     }
 
     @Override

--- a/library/src/main/java/com/sksamuel/jqm4gwt/JQMPageEvent.java
+++ b/library/src/main/java/com/sksamuel/jqm4gwt/JQMPageEvent.java
@@ -1,0 +1,100 @@
+package com.sksamuel.jqm4gwt;
+
+import com.google.gwt.event.logical.shared.HasAttachHandlers;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class JQMPageEvent extends GwtEvent<JQMPageEvent.Handler> {
+
+    public interface Handler extends EventHandler {
+        void onBeforeShow(JQMPageEvent event);
+        void onBeforeHide(JQMPageEvent event);
+        void onShow(JQMPageEvent event);
+        void onHide(JQMPageEvent event);
+    }
+
+    public static class DefaultHandler implements Handler {
+        @Override
+        public void onBeforeShow(JQMPageEvent event) {
+        }
+
+        @Override
+        public void onBeforeHide(JQMPageEvent event) {
+        }
+
+        @Override
+        public void onShow(JQMPageEvent event) {
+        }
+
+        @Override
+        public void onHide(JQMPageEvent event) {
+        }
+    }
+
+    static Type<JQMPageEvent.Handler> TYPE;
+
+    /**
+     * Fires an {@link JQMPageEvent} on all registered handlers in the handler source.
+     *
+     * @param <S> The handler source type
+     * @param source - the source of the handlers
+     */
+    public static <S extends HasAttachHandlers> void fire(S source, PageState pageState) {
+      if (TYPE != null) {
+        JQMPageEvent event = new JQMPageEvent(pageState);
+        source.fireEvent(event);
+      }
+    }
+
+    public static Type<JQMPageEvent.Handler> getType() {
+      if (TYPE == null) {
+        TYPE = new Type<JQMPageEvent.Handler>();
+      }
+      return TYPE;
+    }
+
+    public enum PageState { BEFORE_SHOW, SHOW, BEFORE_HIDE, HIDE }
+
+    private final PageState pageState;
+
+    protected JQMPageEvent(PageState pageState) {
+        this.pageState = pageState;
+    }
+
+    public PageState getPageState() {
+        return pageState;
+    }
+
+    @Override
+    public final Type<JQMPageEvent.Handler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    public String toDebugString() {
+        assertLive();
+        return super.toDebugString() + " pageState = " + pageState;
+    }
+
+    @Override
+    protected void dispatch(JQMPageEvent.Handler handler) {
+        switch (pageState) {
+            case BEFORE_HIDE:
+                handler.onBeforeHide(this);
+                break;
+
+            case HIDE:
+                handler.onHide(this);
+                break;
+
+            case BEFORE_SHOW:
+                handler.onBeforeShow(this);
+                break;
+
+            case SHOW:
+                handler.onShow(this);
+                break;
+        }
+    }
+
+}


### PR DESCRIPTION
That functionality is needed in case of aggregation instead of inheritance. 
Example:

``` java
page.addPageHandler(new JQMPageEvent.DefaultHandler() {
    @Override
    public void onShow(JQMPageEvent event) {
        super.onShow(event);
        loadData();
    }});
```
